### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Or just use it and tell one friend. That's enough.
 ## ⭐ Star History
 
 <p align="center">
-  <a href="https://star-history.com/#akshayaggarwal99/jarvis-ai-assistant&Date">
-    <img src="https://api.star-history.com/svg?repos=akshayaggarwal99/jarvis-ai-assistant&type=Date" width="600" />
+  <a href="https://star-history.dera.page/#akshayaggarwal99/jarvis-ai-assistant&Date">
+    <img src="https://star-history.dera.page/svg?repos=akshayaggarwal99/jarvis-ai-assistant&type=Date" width="600" />
   </a>
 </p>
 


### PR DESCRIPTION
Our star history chart currently shows a blank image because the upstream service relies on GitHub's stargazer API, which is now rate-limited to the point the chart no longer renders. This PR points the chart at star-history.dera.page, an alternative that fetches stars from a different source with no API token needed, restoring the chart in the README.